### PR TITLE
Prevent DB Call By Checking Connection Prior

### DIFF
--- a/lib/solidus_user_roles/engine.rb
+++ b/lib/solidus_user_roles/engine.rb
@@ -19,7 +19,8 @@ module SolidusUserRoles
 
     def self.load_custom_permissions
       # Ensure both tables exist before assigning permissions
-      if (ActiveRecord::Base.connection.tables & ['spree_roles', 'spree_permission_sets']).to_a.length == 2
+      if ActiveRecord::Base.connected? &&
+          (ActiveRecord::Base.connection.tables & ['spree_roles', 'spree_permission_sets']).to_a.length == 2
         ::Spree::Role.non_base_roles.each do |role|
           ::Spree::Config.roles.assign_permissions role.name, role.permission_sets_constantized
         end


### PR DESCRIPTION


When running `rails asset:precompile` the application attempts to initialize, in turn running `ActiveRecord::Base.connection.tables` which calls out to the DB. When building a docker image the DB may not have been created prior to attempting to precompile assets and will in turn fail to compose the image. By checking if there is a connection first. We can prevent this type of failure

Relevant error:  https://github.com/globalize/globalize/issues/723