### PR TITLE
Force DB connection attempt at gem activation time

### DIFF
--- a/lib/solidus_user_roles/engine.rb
+++ b/lib/solidus_user_roles/engine.rb
@@ -18,8 +18,8 @@ module SolidusUserRoles
     end
 
     def self.load_custom_permissions
-      # Ensure both tables exist before assigning permissions
-      if ActiveRecord::Base.connected? &&
+      # Ensure connection to DB is available and both tables exist before assigning permissions
+      if database_connection_available? &&
           (ActiveRecord::Base.connection.tables & ['spree_roles', 'spree_permission_sets']).to_a.length == 2
         ::Spree::Role.non_base_roles.each do |role|
           ::Spree::Config.roles.assign_permissions role.name, role.permission_sets_constantized
@@ -41,5 +41,13 @@ module SolidusUserRoles
     end
 
     config.to_prepare(&method(:activate).to_proc)
+
+    private
+
+    def self.database_connection_available?
+      ActiveRecord::Base.connection rescue false
+
+      ActiveRecord::Base.connected?
+    end
   end
 end


### PR DESCRIPTION
The previous check, unless the database was already connected for some reason, returned false and prevented custom roles to be loaded at startup time.

So, before checking if the connection is available, the fix tries to connect to the DB, and simply rescue any error that may arise, as it happens when compiling assets on Docker. We can't really be specific on the error even if we wanted to, as specific DB gems raise different errors and we'd need to include all of them as dependencies before being able to rescue each error class.

The idea is taken from https://github.com/globalize/globalize/pull/799 so all credits go to the author @djpremier.