### PR TITLE
Allow the removal of permission sets

### DIFF
--- a/app/decorators/models/solidus_user_roles/spree/role_decorator.rb
+++ b/app/decorators/models/solidus_user_roles/spree/role_decorator.rb
@@ -17,7 +17,7 @@ module SolidusUserRoles
       end
 
       def assign_permissions
-        ::Spree::Config.roles.assign_permissions name, permission_sets_constantized
+        ::Spree::Config.roles.roles[name] = ::Spree::RoleConfiguration::Role.new(name, permission_sets_constantized)
       end
 
       ::Spree::Role.prepend self

--- a/spec/models/spree/role_spec.rb
+++ b/spec/models/spree/role_spec.rb
@@ -22,6 +22,13 @@ describe Spree::Role, type: :model do
 
       expect { role.save }.to change { Spree::Config.roles.roles[role.name].permission_sets.count }.from(1).to(2)
     end
+
+    it "removes existing permission sets" do
+      role.save
+      role.permission_sets = []
+
+      expect { role.save }.to change { Spree::Config.roles.roles[role.name].permission_sets.count }.from(1).to(0)
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
The assign_permissions method in solidus_core is only calling concat on the permission set, which is fine for adding new permission sets. In a case on a removal the permission set would persist until the server is restarted.