### PR TITLE
Prevent updating base roles

### DIFF
--- a/app/decorators/models/solidus_user_roles/spree/role_decorator.rb
+++ b/app/decorators/models/solidus_user_roles/spree/role_decorator.rb
@@ -3,13 +3,15 @@
 module SolidusUserRoles
   module Spree
     module RoleDecorator
+      BASE_ROLES = ["admin", "user"]
+
       def self.prepended(base)
         base.has_many :role_permissions, dependent: :destroy
         base.has_many :permission_sets, through: :role_permissions
 
-        base.scope :non_base_roles, -> { where.not(name: ["admin", "user"]) }
+        base.scope :non_base_roles, -> { where.not(name: BASE_ROLES) }
         base.validates_uniqueness_of :name, case_sensitive: false
-        base.after_save :assign_permissions
+        base.after_save :assign_permissions, if: -> { BASE_ROLES.none?(name) }
       end
 
       def permission_sets_constantized

--- a/spec/models/spree/role_spec.rb
+++ b/spec/models/spree/role_spec.rb
@@ -29,6 +29,15 @@ describe Spree::Role, type: :model do
 
       expect { role.save }.to change { Spree::Config.roles.roles[role.name].permission_sets.count }.from(1).to(0)
     end
+
+    it "should not update base roles" do
+      role.name = "admin"
+      role.save
+
+      role.permission_sets = []
+
+      expect { role.save }.to_not change { Spree::Config.roles.roles[role.name].permission_sets.count }
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
This is mostly an issue in test scenarios. The after_save hook will also be called, if an admin user is created in a test factory. It should not be allowed to update the permission sets of base roles.